### PR TITLE
Only use vim.g.compe.source.tabnine keys if vim.g.compe exists

### DIFF
--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -40,8 +40,8 @@ function Source.get_metadata(_)
 		menu = '[TN]';
 		-- by default, do not sort
 		sort = false;
-		max_lines = vim.g.compe.source.tabnine.max_line or 1000;
-		max_num_results = vim.g.compe.source.tabnine.max_num_results or 20;
+		max_lines = (vim.g.compe and vim.g.compe.source.tabnine.max_line) or 1000;
+		max_num_results = (vim.g.compe and vim.g.compe.source.tabnine.max_num_results) or 20;
 	}
 end
 


### PR DESCRIPTION
Trying to read `vim.g.compe.source.tabnine.max_line` and `vim.g.compe.source.tabnine.max_num_results` when `vim.g.compe` doesn't exist (ex. because compe was configured in Lua) breaks all compe completions.

This should fix that.