### PR TITLE
Apply suffix changes returned from TabNine

### DIFF
--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -61,9 +61,13 @@ end
 --- determine
 function Source.determine(_, context)
 	-- dump(context)
-	return compe.helper.determine(context)
+	return compe.helper.determine(context, {
+			trigger_characters = vim.split(
+				"!\"#$%&'()*+,-./0123456789:;<=>?@"
+				.. "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+				"", true)
+		})
 end
-
 
 Source._do_complete = function()
 	-- print('do complete')
@@ -110,10 +114,6 @@ end
 function Source.complete(self, args)
 	Source.callback = args.callback
 	Source._do_complete()
-	args.callback({
-		items = {};
-		incomplete = true;
-	})
 end
 
 Source._on_err = function(_, data, _)

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -116,11 +116,16 @@ function Source.complete(self, args)
 	})
 end
 
---- complete
-function Source.confirm(_, context)
-  local item = context.completed_item
+--- confirm replace suffix
+function Source.confirm(self, option)
+  local item = option.completed_item
 
-  api.nvim_put({item.user_data.new_suffix}, "c", true, false)
+  local pos = api.nvim_win_get_cursor(0)
+  local row = pos[1] - 1
+  local col = pos[2]
+  local len = string.len(item.user_data.old_suffix)
+  api.nvim_buf_set_text(0, row, col, row, col+len, {item.user_data.new_suffix})
+  -- api.nvim_put({item.user_data.new_suffix}, "c", true, false)
 end
 
 

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -116,6 +116,14 @@ function Source.complete(self, args)
 	})
 end
 
+--- complete
+function Source.confirm(_, context)
+  local item = context.completed_item
+
+  api.nvim_put({item.user_data.new_suffix}, "c", true, false)
+end
+
+
 Source._on_err = function(_, data, _)
 end
 
@@ -164,7 +172,12 @@ Source._on_stdout = function(_, data, _)
 					-- dump(results)
 					for _, result in ipairs(results) do
 						if #items < Source.get_metadata().max_num_results then
-							table.insert(items, result.new_prefix)
+							-- table.insert(items, result.new_prefix)
+							local item = {
+								word = result.new_prefix,
+								user_data = result
+							}
+							table.insert(items, item)
 						end
 					end
 				else

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -181,6 +181,7 @@ Source._on_stdout = function(_, data, _)
 							local item = {
 								word = result.new_prefix;
 								user_data = result;
+								filter_text = old_prefix;
 							}
 							table.insert(items, item)
 						end


### PR DESCRIPTION
Hi,

Not the best PR format since it's actually 2 parts:

1. Applies old_suffix -> new_suffix replacement from the result of TabNine. This requires proper mapping of compe's `compe#confirm()` function to confirm a completion.
2. update `determine` function to trigger as a character-triggered source, which will trigger the completion on symbols as well as letters (for example, it will trigger completion on both `Array|` as well as `Array.|`)

One thing I'm not entirely sure is the undocumented `keyword_pattern_offset` you could return along with the completion items
```
			keyword_pattern_offset = pos[2] - #old_prefix + 1;
```
this is necessary to update the proper completion starting point for compe to compute the final list to display (because we use 1 as the initial value when triggering the completion and TabNine calculates the common prefixes of its suggestions.) 

I've been using this setup for a week and it is working well for me but suggestions are always welcome.