### PR TITLE
Setup proper permissions for TabNine executables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ path=$version/$triple
 curl https://update.tabnine.com/bundles/${path}/TabNine.zip --create-dirs -o binaries/${path}/TabNine.zip
 unzip -o binaries/${path}/TabNine.zip -d binaries/${path}
 rm -rf binaries/${path}/TabNine.zip
-chmod +x binaries/$path/TabNine
+chmod +x binaries/$path/*
 
 target="binaries/TabNine_$(uname -s)"
 rm $target || true # remove old link


### PR DESCRIPTION
This is the behaviour of TabNine's installation script.  Deep completion won't be available without setting up other executables (on linux at least. haven't tested on MacOS/Windows). We can set perms on individual executables but since TN's own install script does this already, might as well do the same.

TabNine's download script: https://github.com/codota/TabNine/blob/master/dl_binaries.sh