### PR TITLE
fix binary path which create by TabNine binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,3 @@ curl https://update.tabnine.com/bundles/${path}/TabNine.zip --create-dirs -o bin
 unzip -o binaries/${path}/TabNine.zip -d binaries/${path}
 rm -rf binaries/${path}/TabNine.zip
 chmod +x binaries/$path/*
-
-target="binaries/TabNine_$(uname -s)"
-rm $target || true # remove old link
-ln -sf $path/TabNine $target

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -32,9 +32,11 @@ local function get_paths(root, paths)
 end
 
 
+-- do this once on init, otherwise on restart this dows not work
+local binaries_folder = fn.expand("<sfile>:p:h:h:h") .. "/binaries"
+
 -- locate the binary here, as expand is relative to the calling script name
 local function binary()
-	local binaries_folder = fn.expand("%:p:h:h:h") .. "/binaries"
 	local versions_folders = fn.globpath(binaries_folder, '*', false, true)
 	local versions = {}
 	for _, path in ipairs(versions_folders) do

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -33,7 +33,7 @@ end
 
 
 -- do this once on init, otherwise on restart this dows not work
-local binaries_folder = fn.expand("<sfile>:p:h:h:h") .. "/binaries"
+local binaries_folder = fn.expand('<sfile>:p:h:h:h') .. '/binaries'
 
 -- locate the binary here, as expand is relative to the calling script name
 local function binary()
@@ -50,12 +50,12 @@ local function binary()
 	local latest = versions[#versions]
 
 	local platform = nil
-  local arch, _ = string.gsub(fn.system('uname -m'), "\n$", "")
+  local arch, _ = string.gsub(fn.system('uname -m'), '\n$', '')
 	if fn.has('win32') == 1 then
 		platform = 'i686-pc-windows-gnu'
 	elseif fn.has('win64') == 1 then
 		platform = 'x86_64-pc-windows-gnu'
-	elseif fn.has("mac") == 1 then
+	elseif fn.has('mac') == 1 then
 		if arch == 'arm64' then
 			platform = 'aarch64-apple-darwin'
 		else

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -50,7 +50,7 @@ local function binary()
 	local latest = versions[#versions]
 
 	local platform = nil
-  local arch, _ = string.gsub(fn.system('uname -m'), '\n$', '')
+	local arch, _ = string.gsub(fn.system('uname -m'), '\n$', '')
 	if fn.has('win32') == 1 then
 		platform = 'i686-pc-windows-gnu'
 	elseif fn.has('win64') == 1 then

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -49,18 +49,19 @@ local function binary()
 	local latest = versions[#versions]
 
 	local platform = nil
+  local arch, _ = string.gsub(fn.system('uname -m'), "\n$", "")
 	if fn.has('win32') == 1 then
 		platform = 'i686-pc-windows-gnu'
 	elseif fn.has('win64') == 1 then
 		platform = 'x86_64-pc-windows-gnu'
 	elseif fn.has("mac") == 1 then
-		if fn.system('arch') == 'arm64' then
+		if arch == 'arm64' then
 			platform = 'aarch64-apple-darwin'
 		else
-			platform = 'x86_64-apple-darwin'
+			platform = arch .. '-apple-darwin'
 		end
 	elseif fn.has('unix') == 1 then
-		platform = 'x86_64-unknown-linux-musl'
+		platform = arch .. '-unknown-linux-musl'
 	end
 	return latest.path .. '/' .. platform .. '/' .. 'TabNine'
 end

--- a/lua/compe_tabnine/init.lua
+++ b/lua/compe_tabnine/init.lua
@@ -40,9 +40,10 @@ local function binary()
 	local versions_folders = fn.globpath(binaries_folder, '*', false, true)
 	local versions = {}
 	for _, path in ipairs(versions_folders) do
-		for i in string.gmatch(path, '/[^/]*$') do
-			local version, _ = string.gsub(i, '/', '')
-			table.insert(versions, {path=path, version=version})
+		for version in string.gmatch(path, '/([0-9.]+)$') do
+			if version then
+				table.insert(versions, {path=path, version=version})
+			end
 		end
 	end
 	table.sort(versions, function (a, b) return a.version < b.version end)


### PR DESCRIPTION
## My Environment
- mac big sur 11.5.1 Intel
- NVIM v0.6.0-dev+43-g02bf251bb
- TabNine 3.5.33

## Feature

fix binary path which create by TabNine binary

## Fixed problem
Sometime execute `binaries/TabNine_Darwin` make tabnine binary upside directory, like this.

```
['/Users/user/.cache/dein/repos/github.com/tzachar/0.0.1', '/Users/user/.cache/dein/repos/github.com/tzachar/3.5.35']
```
I don't wanna pollute directory.

Apparently TabNine binary make directory it-self at tow higher level. 
Example for `0.0.1` and `3.5.35` and so on.
So, I want change  Tabnine_xx alis state.

